### PR TITLE
Setting kerb-simplekdc as a test dependency to avoid spurious transitive dependencies

### DIFF
--- a/kerb4j-client/pom.xml
+++ b/kerb4j-client/pom.xml
@@ -44,7 +44,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.kerby</groupId>
+            <artifactId>kerb-simplekdc</artifactId>
+            <version>2.0.1</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/kerb4j-common/pom.xml
+++ b/kerb4j-common/pom.xml
@@ -29,6 +29,7 @@
             <groupId>org.apache.kerby</groupId>
             <artifactId>kerb-simplekdc</artifactId>
             <version>2.0.1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/kerb4j-server/kerb4j-server-spring-security/pom.xml
+++ b/kerb4j-server/kerb4j-server-spring-security/pom.xml
@@ -59,6 +59,12 @@
             <version>${io.sniffy.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kerby</groupId>
+            <artifactId>kerb-simplekdc</artifactId>
+            <version>2.0.1</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/kerb4j-server/kerb4j-server-tomcat/pom.xml
+++ b/kerb4j-server/kerb4j-server-tomcat/pom.xml
@@ -61,6 +61,12 @@
             <version>${tomcat.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kerby</groupId>
+            <artifactId>kerb-simplekdc</artifactId>
+            <version>2.0.1</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 </project>


### PR DESCRIPTION
This is the pull request for the issue (  #35  ) I opened regarding unnecessary compile time scope dependencies.

I only ran `mvn clean install` and it was successfull, not sure if there are any integration tests to run.