### PR TITLE
Support for UPN_DNS_INFO buffer type in PAC

### DIFF
--- a/kerb4j-common/src/main/resources/exceptions.properties
+++ b/kerb4j-common/src/main/resources/exceptions.properties
@@ -21,6 +21,7 @@ kerberos.decrypt.fail=Unable to decrypt encrypted data using key of type {0}.
 pac.token.empty=Empty PAC token.
 pac.token.malformed=Malformed PAC token.
 pac.logoninfo.malformed=Malformed PAC logon info.
+pac.upndnsinfo.malformed=Malformed PAC upn dns info.
 pac.signature.malformed=Malformed PAC signature.
 pac.signature.invalid=Invalid PAC signature.
 pac.string.notempty=String not empty while expected null.

--- a/kerb4j-server/kerb4j-server-common/src/main/java/com/kerb4j/server/marshall/pac/Pac.java
+++ b/kerb4j-server/kerb4j-server-common/src/main/java/com/kerb4j/server/marshall/pac/Pac.java
@@ -20,6 +20,7 @@ public class Pac {
 
     private PacLogonInfo logonInfo;
     private PacCredentialType credentialType;
+    private PacUpnDnsInfo upnDnsInfo;
     private List<PacDelegationInfo> delegationInfos = new ArrayList<>();
     private List<PacDelegationInfo> delegationInfosReadOnly = Collections.unmodifiableList(delegationInfos);
 
@@ -61,6 +62,10 @@ public class Pac {
                         // PAC Credential Type
                         credentialType = new PacCredentialType(bufferData);
                         break;
+                    case PacConstants.UPN_DNS_INFO:
+                        // PAC UPN_DNS_INFO
+                        upnDnsInfo = new PacUpnDnsInfo(bufferData);
+                        break;
                     case PacConstants.S4U_DELEGATION_INFO:
                         // PAC S4U Delegation Info Type, according to [MS-PAC] �2.9, can "be used multiple times"
                         delegationInfos.add(new PacDelegationInfo(bufferData));
@@ -101,6 +106,10 @@ public class Pac {
 
     public PacLogonInfo getLogonInfo() {
         return logonInfo;
+    }
+
+    public PacUpnDnsInfo getUpnDnsInfo() {
+        return upnDnsInfo;
     }
 
     public PacCredentialType getCredentialType() {

--- a/kerb4j-server/kerb4j-server-common/src/main/java/com/kerb4j/server/marshall/pac/PacConstants.java
+++ b/kerb4j-server/kerb4j-server-common/src/main/java/com/kerb4j/server/marshall/pac/PacConstants.java
@@ -10,6 +10,7 @@ public interface PacConstants {
 
     int CLIENT_INFO_TYPE = 10;
     int S4U_DELEGATION_INFO = 11;
+    int UPN_DNS_INFO = 0x0c;
 
     int LOGON_EXTRA_SIDS = 0x20;
     int LOGON_RESOURCE_GROUPS = 0x200;

--- a/kerb4j-server/kerb4j-server-common/src/main/java/com/kerb4j/server/marshall/pac/PacUpnDnsInfo.java
+++ b/kerb4j-server/kerb4j-server-common/src/main/java/com/kerb4j/server/marshall/pac/PacUpnDnsInfo.java
@@ -1,0 +1,155 @@
+package com.kerb4j.server.marshall.pac;
+
+import com.kerb4j.server.marshall.Kerb4JException;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Structure representing the UPN_DNS_INFO record
+ * <p>
+ * <a href="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/166d8064-c863-41e1-9c23-edaaa5f36962?redirectedfrom=MSDN">Section 2.10 UPN_DNS_INFO</a>
+ *
+ * @author vfalta@techniserv.cz
+ */
+public class PacUpnDnsInfo {
+    public static final int FLAG_HAS_UPN_BIT = 0x1;
+    public static final int FLAG_HAS_SAM_BIT = 0x2;
+
+    private final String upn;
+    private final String dnsDomainName;
+
+    private final int flags;
+
+    /**
+     * Only present if the FLAG_HAS_SAM_BIT is set.
+     * Check the hasSam() method.
+     */
+    private String sam;
+
+    /**
+     * Only present if the FLAG_HAS_UPN_BIT is set
+     * Check the hasSam() method.
+     */
+    private PacSid sid;
+
+    public PacUpnDnsInfo(byte[] bufferData) throws Kerb4JException {
+        try {
+            PacDataInputStream pacStream = new PacDataInputStream(new DataInputStream(
+                    new ByteArrayInputStream(bufferData)));
+
+            short upnLength = pacStream.readShort();
+            short upnOffset = pacStream.readShort();
+
+            short dnsDomainNameLength = pacStream.readShort();
+            short dnsDomainNameOffset = pacStream.readShort();
+
+            flags = pacStream.readInt();
+
+            if (hasSam()) {
+                readSam(bufferData, pacStream);
+                readSid(bufferData, pacStream);
+            }
+
+            upn = readString(bufferData, upnLength, upnOffset);
+
+            dnsDomainName = readString(bufferData, dnsDomainNameLength, dnsDomainNameOffset);
+        } catch (IOException e) {
+            throw new Kerb4JException("pac.upndnsinfo.malformed", null, e);
+        }
+    }
+
+    /**
+     * Get the userPrincipalName (UPN) attribute or UPN constructed from username and dnsDomainName fields
+     *
+     * @return the user's UPN
+     */
+    public String getUpn() {
+        return upn;
+    }
+
+    /**
+     * Get the DNS domain name of the user
+     *
+     * @return the user's DNS domain name
+     */
+    public String getDnsDomainName() {
+        return dnsDomainName;
+    }
+
+    /**
+     * Raw flags field from the UPN_DNS_INFO structure
+     *
+     * @return the flags field
+     */
+    public int getFlags() {
+        return flags;
+    }
+
+    /**
+     * @return whether the userPrincipalName attribute is set explicitly or
+     * was constructed from username and domainName fields
+     */
+    public boolean hasUpn() {
+        return (flags & FLAG_HAS_UPN_BIT) != 0;
+    }
+
+    /**
+     * @return Whether the SAM and SID fields are present
+     */
+    public boolean hasSam() {
+        return (flags & FLAG_HAS_SAM_BIT) != 0;
+    }
+
+    /**
+     * Get the sAMAccountName attribute
+     *
+     * @return the user's SAM
+     */
+    public String getSam() {
+        if (!hasSam()) {
+            throw new IllegalStateException("No SAM present");
+        }
+        return sam;
+    }
+
+    /**
+     * Get the SID of the user
+     *
+     * @return the user's SID
+     */
+    public PacSid getSid() {
+        if (!hasSam()) {
+            throw new IllegalStateException("No SAM present");
+        }
+        return sid;
+    }
+
+    private void readSam(byte[] bufferData, PacDataInputStream pacStream) throws IOException {
+        short samLength = pacStream.readShort();
+        short samOffset = pacStream.readShort();
+
+        sam = readString(bufferData, samLength, samOffset);
+    }
+
+    private void readSid(byte[] bufferData, PacDataInputStream pacStream) throws IOException, Kerb4JException {
+        short sidLength = pacStream.readShort();
+        short sidOffset = pacStream.readShort();
+
+        sid = new PacSid(readByteString(bufferData, sidLength, sidOffset));
+    }
+
+    private String readString(byte[] bufferData, short length, short offset) {
+        byte[] data = new byte[length];
+        System.arraycopy(bufferData, offset, data, 0, length);
+        return new String(data, StandardCharsets.UTF_16LE);
+    }
+
+    private byte[] readByteString(byte[] bufferData, short length, short offset) {
+        byte[] data = new byte[length];
+        System.arraycopy(bufferData, offset, data, 0, length);
+        return data;
+    }
+}

--- a/kerb4j-server/kerb4j-server-common/src/test/java/com/kerb4j/server/marshall/TestPac.java
+++ b/kerb4j-server/kerb4j-server-common/src/test/java/com/kerb4j/server/marshall/TestPac.java
@@ -66,6 +66,11 @@ public class TestPac {
             Assertions.assertEquals("DOMAIN", pac.getLogonInfo().getDomainName());
             Assertions.assertEquals("WS2008", pac.getLogonInfo().getServerName());
 
+            Assertions.assertEquals("user.test@domain.com", pac.getUpnDnsInfo().getUpn());
+            Assertions.assertEquals("DOMAIN.COM", pac.getUpnDnsInfo().getDnsDomainName());
+            Assertions.assertFalse(pac.getUpnDnsInfo().hasUpn());
+            Assertions.assertFalse(pac.getUpnDnsInfo().hasSam());
+
         } catch (Kerb4JException e) {
             e.printStackTrace();
             Assertions.fail(e.getMessage());
@@ -87,6 +92,11 @@ public class TestPac {
             Assertions.assertEquals(48, pac.getLogonInfo().getLogonCount());
             Assertions.assertEquals("DOMAIN", pac.getLogonInfo().getDomainName());
             Assertions.assertEquals("WS2008", pac.getLogonInfo().getServerName());
+
+            Assertions.assertEquals("user.test@domain.com", pac.getUpnDnsInfo().getUpn());
+            Assertions.assertEquals("DOMAIN.COM", pac.getUpnDnsInfo().getDnsDomainName());
+            Assertions.assertFalse(pac.getUpnDnsInfo().hasUpn());
+            Assertions.assertFalse(pac.getUpnDnsInfo().hasSam());
 
         } catch (Kerb4JException e) {
             e.printStackTrace();


### PR DESCRIPTION
This pull request adds support for the UPN_DNS_INFO buffer type of PAC structure into the Pac class.

 UPN support is needed to enable access to UPN names which are used for user authentication in organizations with federated AD.

The buffer specification is available at https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/166d8064-c863-41e1-9c23-edaaa5f36962?redirectedfrom=MSDN in section 2.10.